### PR TITLE
Fix Chrome/Chromium version detection

### DIFF
--- a/library/Pdfexport/HeadlessChrome.php
+++ b/library/Pdfexport/HeadlessChrome.php
@@ -196,7 +196,7 @@ class HeadlessChrome
     /**
      * Get the major version number of Chrome or false on failure
      *
-     * @return  int
+     * @return  int|false
      *
      * @throws  \Exception
      */
@@ -213,10 +213,10 @@ class HeadlessChrome
             throw new \Exception($output->stderr);
         }
 
-        $parts = explode(' ', trim($output->stdout));
+        if (preg_match('/\s(\d+)\.[\d\.]+\s/', $output->stdout, $match)) {
+            return (int) $match[1];
+        }
 
-        $version = (int) array_pop($parts);
-
-        return $version;
+        return false;
     }
 }


### PR DESCRIPTION
On RHEL 7, using Chromium PDF Export fails. 
This is caused by the version of Chome `Google Chrome 73.0.3683.103` which is different from Chromium `Chromium 73.0.3683.86 Fedora Project`.

It should mitigate [icingaweb2-module-reporting issue #7](https://github.com/Icinga/icingaweb2-module-reporting/issues/7).