### PR TITLE
Added instructions on how to set the path

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -62,4 +62,8 @@ apt-get install google-chrome-stable
 2. Log in with a privileged user in Icinga Web 2 and enable the module in `Configuration -> Modules -> pdfexport`.
 Or use the `icingacli` and run `icingacli module enable pdfexport`.
 
+3. You might need to set the absolute path to the Google Chrome / Chromium
+binary, depending on your system. This can be done in
+`Configuration -> Modules -> pdfexport -> Binary`
+
 This concludes the installation. PDF exports now use Google Chrome/Chromium for rendering.


### PR DESCRIPTION
On the systems I've used pdfexport on, I have always had to change the path to the binary. It would probably be helpful to include instructions on how to change it.