### PR TITLE
Correct default binary path

### DIFF
--- a/application/forms/ChromeBinaryForm.php
+++ b/application/forms/ChromeBinaryForm.php
@@ -20,7 +20,7 @@ class ChromeBinaryForm extends ConfigForm
     {
         $this->addElement('text', 'chrome_binary', [
             'label'       => $this->translate('Local Binary'),
-            'placeholder' => '/bin/google-chrome',
+            'placeholder' => '/usr/bin/google-chrome',
             'validators'  => [new Zend_Validate_Callback(function ($value) {
                 $chrome = (new HeadlessChrome())
                     ->setBinary($value);

--- a/library/Pdfexport/ProvidedHook/Pdfexport.php
+++ b/library/Pdfexport/ProvidedHook/Pdfexport.php
@@ -38,7 +38,7 @@ class Pdfexport extends PdfexportHook
 
     public static function getBinary()
     {
-        return Config::module('pdfexport')->get('chrome', 'binary', '/bin/google-chrome');
+        return Config::module('pdfexport')->get('chrome', 'binary', '/usr/bin/google-chrome');
     }
 
     public static function getHost()


### PR DESCRIPTION
Most installations seem to install chrome by default to `/usr/bin` rather than `/bin`.