### PR TITLE
Add documentation to point out that proc_open needs to be allowed (not in disable_functions in php.ini)

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements <a id="installation-requirements"></a>
 
-* PHP (>= 7.1)
+* PHP (>= 7.1) with the function `proc_open()` allowed (e.g not listed in `disable_functions`)
 * [Icinga Web 2](https://github.com/Icinga/icingaweb2) (>= 2.6)
 * [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (>= 0.10)
 * [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (>= 0.7)

--- a/doc/70-Troubleshooting.md
+++ b/doc/70-Troubleshooting.md
@@ -2,9 +2,26 @@
 
 ## PDF Export <a id="troubleshooting-pdf-export"></a>
 
+### Check the Google Chrome version
+
 If the PDF export fails, ensure that Chrome headless works fine.
 You can test that on the CLI like this:
 
 ```
 google-chrome --version
 ```
+
+Ensure you are on a recent version - this module expects the version
+to be 59 or higher.
+
+### proc_open() needs to be allowed in PHP
+
+If you are still getting an error message such as:
+
+```
+Can't export: Icinga\Module\Pdfexport\ProvidedHook\Pdfexport does not support exporting PDFs
+```
+
+check that `proc_open` is not listed in `disable_functions` in your
+php.ini configuration. This function is called in order to generate
+the PDF.


### PR DESCRIPTION
Hi,

Thanks for this module.

I was getting this error message even though I was 100% certain that I had google-chrome installed and that the version was the very latest available:

```
Exception in /usr/share/icingaweb2/modules/pdfexport/library/Pdfexport/ProvidedHook/Pdfexport.php:27 with message: Can't export: Icinga\Module\Pdfexport\ProvidedHook\Pdfexport does not support exporting PDFs    
#0 /usr/share/icingaweb2/modules/reporting/application/controllers/ReportController.php(119): Icinga\Module\Pdfexport\ProvidedHook\Pdfexport::first()
#1 /usr/share/icingaweb2/library/vendor/Zend/Controller/Action.php(507): 
Icinga\Module\Reporting\Controllers\ReportController->downloadAction()    
#2 /usr/share/php/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch(String)    
#3 /usr/share/icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))    
#4 /usr/share/php/Icinga/Application/Web.php(304): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#5 /usr/share/php/Icinga/Application/webrouter.php(107): Icinga\Application\Web->dispatch()
#6 /usr/share/icingaweb2/public/index.php(4): require_once(String)
#7 {main}
```

After a lot of digging, and actually commenting out the check on `isSupported()`, it surfaced the actual underlying root cause, which was that `proc_open` was in my list of `disable_functions` in my php.ini configuration.

This just updates to the documentation to make it clear that proc_open needs to be allowed for the module to work.

Thanks again.