### PR TITLE
Fix incorrect page breaks

### DIFF
--- a/library/Pdfexport/PrintableHtmlDocument.php
+++ b/library/Pdfexport/PrintableHtmlDocument.php
@@ -149,14 +149,15 @@ CSS;
     protected $pageRanges;
 
     /**
-     * Page height in pixels minus any vertical margins, footer and header
+     * Page height in pixels
      *
-     * The default is roughly the amount of pixels matching the default paper height of 11 inches at scale 1.
+     * Minus the default vertical margins, this is 1035.
+     * If the vertical margins are zero, it's 1160.
+     * Whether there's a header or footer doesn't matter in any case.
      *
-     * @todo Find out why subtracting the vertical margins leaves unused space behind (with a height of ~980px)
      * @var int
      */
-    protected $pagePixelHeight = 1056;
+    protected $pagePixelHeight = 1035;
 
     /**
      * HTML template for the print header


### PR DESCRIPTION
I fear that this will break with a different chrome version. But I found no other way than this.
There is no working/reliable dynamic way to identify the available max height in headless mode.
The numbers result from manual tests with a custom pixel grid and chrome 97.0.4688.2.

Also tested on 96.0.4664.45, works fine there.

fixes #42