### PR TITLE
Provide a config option to force local temp storage

### DIFF
--- a/application/forms/ChromeBinaryForm.php
+++ b/application/forms/ChromeBinaryForm.php
@@ -47,6 +47,10 @@ class ChromeBinaryForm extends ConfigForm
             })]
         ]);
 
+        $this->addElement('checkbox', 'chrome_force_temp_storage', [
+            'label'     => $this->translate('Force local temp storage')
+        ]);
+
         $this->addElement('text', 'chrome_host', [
             'label'         => $this->translate('Remote Host'),
             'validators'    => [new Zend_Validate_Callback(function ($value) {

--- a/doc/70-Troubleshooting.md
+++ b/doc/70-Troubleshooting.md
@@ -8,3 +8,9 @@ You can test that on the CLI like this:
 ```
 google-chrome --version
 ```
+
+If you have a local installation, you could also try to force temporary local
+storage. (Available in the module's configuration) This will store the content
+to print on disk, instead of transferring it directly to the browser. Note that
+for this to work, the browser needs to be able to access the temporary files of
+the webserver's process user.

--- a/library/Pdfexport/ProvidedHook/Pdfexport.php
+++ b/library/Pdfexport/ProvidedHook/Pdfexport.php
@@ -42,6 +42,11 @@ class Pdfexport extends PdfexportHook
         return Config::module('pdfexport')->get('chrome', 'binary', '/usr/bin/google-chrome');
     }
 
+    public static function getForceTempStorage()
+    {
+        return (bool) Config::module('pdfexport')->get('chrome', 'force_temp_storage', '0');
+    }
+
     public static function getHost()
     {
         return Config::module('pdfexport')->get('chrome', 'host');
@@ -67,7 +72,7 @@ class Pdfexport extends PdfexportHook
         // the object is destructed
         $chrome = $this->chrome();
 
-        $pdf = $chrome->fromHtml($html)->toPdf();
+        $pdf = $chrome->fromHtml($html, static::getForceTempStorage())->toPdf();
 
         if ($html instanceof PrintableHtmlDocument && ($coverPage = $html->getCoverPage()) !== null) {
             $coverPagePdf = $chrome
@@ -95,7 +100,7 @@ class Pdfexport extends PdfexportHook
         // the object is destructed
         $chrome = $this->chrome();
 
-        $pdf = $chrome->fromHtml($html)->toPdf();
+        $pdf = $chrome->fromHtml($html, static::getForceTempStorage())->toPdf();
 
         if ($html instanceof PrintableHtmlDocument && ($coverPage = $html->getCoverPage()) !== null) {
             $coverPagePdf = $chrome


### PR DESCRIPTION
Chromium (90.0.4430.212 and 95.0.4638.69) seems to have
problems with `Page.setDocumentContent` depending on the
content. I was not able to identify the exact content
that causes a "Connection reset by peer" (which is the
real error behind "Failed to write XXXX bytes") but using
a temporary file instead works fine.

refs #48