### PR TITLE
Support Modern Remote Chrome

### DIFF
--- a/library/Pdfexport/HeadlessChrome.php
+++ b/library/Pdfexport/HeadlessChrome.php
@@ -763,8 +763,10 @@ JS;
             // ref: https://issues.chromium.org/issues/40090537
             if (strstr($e->getMessage(), 'Host header is specified and is not an IP address or localhost.')) {
                 $response = $client->request(
-                    'GET', sprintf('http://%s:%s/json/version', $host, $port),
-                    ['headers' => ['Host' => null]]);
+                    'GET',
+                    sprintf('http://%s:%s/json/version', $host, $port),
+                    ['headers' => ['Host' => null]]
+                );
             } else {
                 throw $e;
             }


### PR DESCRIPTION
Starting in version 66, Chrome DevTools requires the host header to be “localhost” or an IP address. Work around this by setting the header to “lcoalhost” when fetching the version endpoint.