### PR TITLE
Replace deprecated methods and interfaces of `react/promise`

### DIFF
--- a/library/Pdfexport/HeadlessChrome.php
+++ b/library/Pdfexport/HeadlessChrome.php
@@ -15,7 +15,7 @@ use React\ChildProcess\Process;
 use React\EventLoop\Loop;
 use React\EventLoop\TimerInterface;
 use React\Promise;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use Throwable;
 use WebSocket\Client;
 
@@ -244,9 +244,9 @@ JS;
     /**
      * Generate a PDF raw string asynchronously.
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function asyncToPdf(): ExtendedPromiseInterface
+    public function asyncToPdf(): PromiseInterface
     {
         $deferred = new Promise\Deferred();
         Loop::futureTick(function () use ($deferred) {
@@ -397,9 +397,8 @@ JS;
     public function toPdf()
     {
         $pdf = '';
-        // We don't intend to register any then/otherwise handlers, so call done on that promise
-        // to properly propagate unhandled exceptions to the caller.
-        $this->asyncToPdf()->done(function (string $newPdf) use (&$pdf) {
+
+        $this->asyncToPdf()->then(function (string $newPdf) use (&$pdf) {
             $pdf = $newPdf;
         });
 

--- a/library/Pdfexport/ProvidedHook/Pdfexport.php
+++ b/library/Pdfexport/ProvidedHook/Pdfexport.php
@@ -14,7 +14,7 @@ use Icinga\File\Storage\TemporaryLocalFileStorage;
 use Icinga\Module\Pdfexport\HeadlessChrome;
 use Icinga\Module\Pdfexport\PrintableHtmlDocument;
 use Karriere\PdfMerge\PdfMerge;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 class Pdfexport extends PdfexportHook
 {
@@ -98,9 +98,9 @@ class Pdfexport extends PdfexportHook
      *
      * @param PrintableHtmlDocument|string $html
      *
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      */
-    public function asyncHtmlToPdf($html): ExtendedPromiseInterface
+    public function asyncHtmlToPdf($html): PromiseInterface
     {
         // Keep reference to the chrome object because it is using temp files which are automatically removed when
         // the object is destructed
@@ -109,7 +109,7 @@ class Pdfexport extends PdfexportHook
         $pdfPromise = $chrome->fromHtml($html, static::getForceTempStorage())->asyncToPdf();
 
         if ($html instanceof PrintableHtmlDocument && ($coverPage = $html->getCoverPage()) !== null) {
-            /** @var ExtendedPromiseInterface $pdfPromise */
+            /** @var PromiseInterface $pdfPromise */
             $pdfPromise = $pdfPromise->then(function (string $pdf) use ($chrome, $html, $coverPage) {
                 return $chrome->fromHtml(
                     (new PrintableHtmlDocument())


### PR DESCRIPTION
Replace deprecated methods and interfaces of `react/promise`

- Method `done()` has been removed, use `then()` instead.
- `ExtendedPromiseInterface` is replaced with `PromiseInterface` since `v3.0.0`:
   https://reactphp.org/promise/changelog.html#300-2023-07-1

requires: 

- [x] Icinga/icinga-php-thirdparty#93

refs #78