### PR TITLE
Upgrade minimum required versions of ipl and icinga-php-thirdparty

### DIFF
--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Module: PDF Export
 Version: 0.12.0
 Requires:
-  Libraries: icinga-php-library (>=0.17.1), icinga-php-thirdparty (>=0.13.0)
+  Libraries: icinga-php-library (>=1.0.0), icinga-php-thirdparty (>=1.0.0)
 Description: PDF Export via Google Chrome/Chromium


### PR DESCRIPTION
Raises the minimum required version of icinga-php-library to >=1.0.0 and icinga-php-thirdparty to >=1.0.0.


icinga-php-thirdparty 1.0.0 updates react/promise from 2.11.0 to 3.3.0 to support PHP 8.5: 
- PHP 8.4 support was introduced in v3.2.0
- PHP 8.5 support in v3.3.0.

Earlier versions of this module depended on that package being available through icinga-php-thirdparty, so requiring at least 1.0.0 ensures compatibility with the updated dependency set.