### PR TITLE
Close Chrome process pipes before termination to prevent loop hang

### DIFF
--- a/library/Pdfexport/HeadlessChrome.php
+++ b/library/Pdfexport/HeadlessChrome.php
@@ -313,7 +313,7 @@ JS;
                     }
 
                     $killer = Loop::addTimer(10, function (TimerInterface $timer) use ($chrome, $deferred) {
-                        $chrome->terminate(6); // SIGABRT
+                        $this->terminateProcess($chrome, 6); // SIGABRT
 
                         Logger::error(
                             'Browser timed out after %d seconds without the expected output',
@@ -346,7 +346,7 @@ JS;
                                 Logger::error('Failed to print PDF. An error occurred: %s', $e);
                             }
 
-                            $chrome->terminate();
+                            $this->terminateProcess($chrome);
 
                             if (! empty($pdf)) {
                                 $deferred->resolve($pdf);
@@ -687,6 +687,26 @@ JS;
         } while ($wait);
 
         return $params;
+    }
+
+    /**
+     * Terminate a process and close pipes inherited by subprocesses
+     *
+     * Chrome spawns sub-processes that inherit open pipes. Close them before termination
+     * so the event loop is not kept alive by inherited file descriptors.
+     *
+     * @param Process $process The process to terminate
+     * @param ?int $signal The signal passed to Process::terminate()
+     *
+     * @return void
+     */
+    private function terminateProcess(Process $process, ?int $signal = null): void
+    {
+        foreach ($process->pipes as $pipe) {
+            $pipe->close();
+        }
+
+        $process->terminate($signal);
     }
 
     /**


### PR DESCRIPTION
Chrome spawns renderer and utility sub-processes that inherit the open stdin, stdout, and stderr pipes of the main browser process. When only the main process is terminated via `Process::terminate()`, those child processes keep the inherited file descriptors open. ReactPHP's event loop stays alive watching those streams, so `Loop::run()` never returns and PDF generation hangs indefinitely.

Close all process pipes explicitly before calling `terminate()` so the event loop has no remaining streams to watch and can exit cleanly.